### PR TITLE
[CRITICAL] [URGENT] CRITICAL BUG FIX

### DIFF
--- a/src/main/java/it/polimi/ingsw/view/gui/fxml/InitSelectPionScene.fxml
+++ b/src/main/java/it/polimi/ingsw/view/gui/fxml/InitSelectPionScene.fxml
@@ -23,8 +23,9 @@
                 <Text styleClass="title" text="Select your Pion"/>
                 <ImageView fx:id="pionImageView" fitHeight="200" fitWidth="200" styleClass="card"/>
                 <HBox spacing="20" alignment="CENTER" maxWidth="600">
-                    <Button onAction="#previousPion" styleClass="brutalist-button" text="Previous"/>
-                    <Button onAction="#nextPion" styleClass="brutalist-button" text="Next"/>
+                    <Button onAction="#previousPion" styleClass="brutalist-button" text="Previous"
+                            focusTraversable="false"/>
+                    <Button onAction="#nextPion" styleClass="brutalist-button" text="Next" focusTraversable="false"/>
                 </HBox>
                 <Button onAction="#continueAction" styleClass="brutalist-button" text="Continue"/>
             </VBox>


### PR DESCRIPTION
This PR addresses a **critical bug** in our JavaFX GUI related to key press event handling. The issue was that the onKeyPressed event on the root AnchorPane was not being triggered when the Enter key was pressed. This is a **crucial functionality** for our application as it is responsible for triggering the continueAction() method, which is essential for the progression of the game.

The root cause of the issue was that the root AnchorPane was not receiving focus, and in JavaFX, only the node that has focus can receive keyboard input events. This was due to the fact that one of the buttons was being selected by default when the scene was loaded, thereby receiving the focus instead of the root AnchorPane. 

The fix involves setting the focusTraversable property of each button to false, which prevents them from receiving focus when the scene is loaded. This allows the root AnchorPane to receive the focus and hence the keyboard input events.  Without this fix, the **game cannot progress past the initial scene**, making it impossible for users to interact with the application beyond this point. Therefore, it is of utmost importance that this bug is fixed to ensure the proper functioning of our application.